### PR TITLE
push: make clipboard copying work in Linux

### DIFF
--- a/push
+++ b/push
@@ -41,7 +41,9 @@ if [[ "$remote_url" =~ "github.com" ]]; then
 
   repo_name=$(echo $remote_url | sed 's/.*\:\(.*\)\.git/\1/')
   github_url="https://github.com/$repo_name/compare/$refs"
-  which -s pbcopy && echo $github_url | pbcopy && echo "Compare URL copied to clipboard!"
+  copied="Compare URL copied to clipboard!"
+  which -s pbcopy >& /dev/null && echo $github_url | pbcopy && echo $copied
+  which xclip >& /dev/null && echo $github_url | xclip -selection clipboard && echo $copied
   # which -s open && open -g $github_url
 
   echo $github_url


### PR DESCRIPTION
Also, silence `which -s` and `which` output to avoid unnecessary buzz on systems without `xclip` and `pbcopy`. 
Please make sure that I didn't break Mac OS X copying, I have no machine I could check it on.
