### PR TITLE
install: allow installing in custom destination

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 here=$(pwd -P)
 tmp="/tmp/git-friendly"
-dest="/usr/local/bin"
+[ $1 ] && dest=$1 || dest="/usr/local/bin"
 
 git clone git://github.com/jamiew/git-friendly.git $tmp >/dev/null 2>&1
 rm -rf $tmp/.git


### PR DESCRIPTION
May be useful for installing in `~/bin` or `/usr/bin` instead of `/usr/local/bin`.
When command line parameter is supplied, it uses it as a install prefix.

(Sorry for flooding you.)
