### PR TITLE
install: make sure that install directory exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ git clone git://github.com/jamiew/git-friendly.git $tmp >/dev/null 2>&1
 rm -rf $tmp/.git
 rm -f $tmp/README* $tmp/install.sh
 installed_scripts=`ls -1 ${tmp}`
+mkdir -p ${dest}
 cp $tmp/* ${dest}/ &> /dev/null
 rm -rf $tmp
 for s in ${installed_scripts}; do


### PR DESCRIPTION
Installing with default options resulted in misleading message, saying that I don't have rights to install to `/usr/local/bin`, while this directory didn't exist at all.

(I keep my pull request limited to one issue at the time, just tell me if you don't like it.)
