### PR TITLE
Do not show error when bundle or npm is not istalled

### DIFF
--- a/pull
+++ b/pull
@@ -37,13 +37,13 @@ fi
 git remote prune $remote >/dev/null 2>&1 &
 
 # Bundle em if you got em!
-if which bundle >/dev/null && [ -f Gemfile ]; then
+if which bundle >/dev/null 2>&1 && [ -f Gemfile ]; then
   echo "* Bundling gems..."
   bundle check >/dev/null 2>&1 || bundle install
 fi
 
 # Install node.js/npm packages
-if which npm >/dev/null && [ -f package.json ]; then
+if which npm >/dev/null 2>&1 && [ -f package.json ]; then
   echo "* Installing npm packages..."
   npm install
 fi


### PR DESCRIPTION
On Linux I get this to annoying errors:

```
which: no bundle in (/home/asapegin/bin:/home/asapegin/dotfiles/bin:/local/bin:/local/php5/bin:/local/utils:/usr/lib64/mpi/gcc/openmpi/bin:/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin:/local/php5/bin)
which: no npm in (/home/asapegin/bin:/home/asapegin/dotfiles/bin:/local/bin:/local/php5/bin:/local/utils:/usr/lib64/mpi/gcc/openmpi/bin:/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin:/local/php5/bin)
```

Which actually is not errors so I suppress them.
