### PR TITLE
Fixed Compare URL

### DIFF
--- a/push
+++ b/push
@@ -47,7 +47,7 @@ remote_url=$(git remote show $remote -n | grep Push | awk '{ print $3 }')
 if [[ "$remote_url" =~ "github.com" ]]; then
 
   repo_name=$(echo $remote_url | sed 's/.*\:\(.*\)\.git/\1/')
-  github_url="https://github.com/$repo_name/compare/$refs"
+  github_url="https:$repo_name/compare/$refs"
   copied="Compare URL copied to clipboard!"
   which pbcopy >& /dev/null && echo $github_url | pbcopy && echo $copied
   which xclip >& /dev/null && echo $github_url | xclip -selection clipboard && echo $copied


### PR DESCRIPTION
Fixes https://github.com/jamiew/git-friendly/issues/24 `push` makes bad compare urls for https://github.com checkouts
