### PR TITLE
Fixed Repo name/URL selection

### DIFF
--- a/push
+++ b/push
@@ -46,8 +46,9 @@ fi
 remote_url=$(git remote show $remote -n | grep Push | awk '{ print $3 }')
 if [[ "$remote_url" =~ "github.com" ]]; then
 
-  repo_name=$(echo $remote_url | sed 's/.*\:\(.*\)\.git/\1/')
-  github_url="https://github.com/$repo_name/compare/$refs"
+  repo_url=$(echo $remote_url | sed 's/\(.*\)\.git/\1/')
+  github_url="$repo_url/compare/$refs"
+
   copied="Compare URL copied to clipboard!"
   which pbcopy >& /dev/null && echo $github_url | pbcopy && echo $copied
   which xclip >& /dev/null && echo $github_url | xclip -selection clipboard && echo $copied


### PR DESCRIPTION
Changed the regexp to avoid duplicated 'github.com://'
Fixes issue https://github.com/jamiew/git-friendly/issues/24/
