### PR TITLE
Pop stashed changes on pull error

### DIFF
--- a/pull
+++ b/pull
@@ -6,6 +6,28 @@
 # safely stashing and re-applying your local changes, if any
 #
 
+# Colors
+color_error="$(tput sgr 0 1)$(tput setaf 1)"
+color_reset="$(tput sgr0)"
+
+# Pop any stashed changes
+unstash() {
+	if [[ "$stash" =~ "No local changes to save" ]]; then
+	  echo "* No stashed changes, not popping"
+	else
+	  echo "* Popping stash..."
+	  git stash pop
+	fi
+}
+
+# Pop any stashed changes and exit
+rollback() {
+	echo
+	echo "${color_error}Something went wrong, rolling back${color_reset}"
+	unstash
+	exit $1
+}
+
 branch=$(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') || exit $?
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
@@ -15,23 +37,17 @@ remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branc
 stash=$(git stash)
 
 # Update our remote
-echo "Fetching from $remote ..."
-git fetch $remote || exit $?
+echo "Fetching from $remote..."
+git fetch $remote || rollback $?
 
 # Pull, using rebase if configured
 rebase="--rebase" # TODO disable if env-var is set
-git pull $rebase $remote $remote_branch || exit $?
+git pull $rebase $remote $remote_branch || rollback $?
 
 # Update submodules
-git submodule update || exit $?
+git submodule update || rollback $?
 
-# Pop any stashed changes
-if [[ "$stash" =~ "No local changes to save" ]]; then
-  echo "* No stashed changes, not popping"
-else
-  echo "* Popping stash..."
-  git stash pop
-fi
+unstash
 
 # Remove old, stale branches
 git remote prune $remote >/dev/null 2>&1 &


### PR DESCRIPTION
For example I try to `pull` local branch:

```
❯ git status
On branch test
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:   pull

no changes added to commit (use "git add" and/or "git commit -a")

❯ pull
Fetching from origin ...
fatal: Couldn't find remote ref test

❯ git status
On branch test
nothing to commit, working directory clean
```

Now I have all my uncommitted changes in a stash and a clean tree which isn’t obvious and a bit annoying.
