### PR TITLE
Support branches containing slash (eg. feature/redesign)

### DIFF
--- a/merge
+++ b/merge
@@ -8,7 +8,7 @@
 
 remote="origin"
 branch=$1
-current_branch=$(git branch 2>/dev/null|grep -e ^* | tr -d \*//)
+current_branch=$(git branch 2>/dev/null|grep -e ^* | tr -d \*)
 
 if [ -z $branch ]; then
   echo "Usage: $0 [branchname]"

--- a/pull
+++ b/pull
@@ -31,7 +31,7 @@ rollback() {
 branch=$(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') || exit $?
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
-remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | awk -F '/' '{ print $3 }' )
+remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3- )
 
 # Stash any local changes
 stash=$(git stash)

--- a/push
+++ b/push
@@ -18,7 +18,7 @@ color_reset="$(tput sgr0)"
 branch=$(git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') || exit $?
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
-remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | awk -F '/' '{ print $3 }' )
+remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3- )
 
 # Push & save output
 push=$(git push --set-upstream $* $remote $remote_branch 2>&1)


### PR DESCRIPTION
Current version doesn't support branches  containing slash (eg. feature/redesign).

Now **Push** and **Pull** commands use everything after 2nd slash as a branch name.
On the other hand, **Merge** command now allows slashes in branch names.
