### PR TITLE
Install composer packages after pulling if applicable

### DIFF
--- a/pull
+++ b/pull
@@ -87,6 +87,15 @@ if [ "$GIT_FRIENDLY_NO_BOWER" != "true" ]; then
   fi
 fi
 
+# Install Composer packages
+if [ "$GIT_FRIENDLY_NO_COMPOSER" != "true" ]; then
+  if which composer >/dev/null 2>&1 && [ -f composer.json ]; then
+    echo
+    echo "⚔  Installing Composer packages..."
+    composer install
+  fi
+fi
+
 echo
 echo "🦄  Done"
 exit 0


### PR DESCRIPTION
If a `composer.json` file exists and `composer` is available, this will run `composer install` after `pull`.

Can be disabled using the `GIT_FRIENDLY_NO_COMPOSER` env variable like for the other dependency managers.

Fixes #45.