### PR TITLE
Removes .gitignore from install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ tmp="/tmp/git-friendly"
 
 git clone https://github.com/jamiew/git-friendly.git $tmp >/dev/null 2>&1
 rm -rf $tmp/.git
-rm -f $tmp/README* $tmp/install.sh
+rm -f $tmp/README* $tmp/install.sh $tmp/.gitignore
 installed_scripts=`ls -1 ${tmp}`
 mkdir -p ${dest}
 cp $tmp/* ${dest}/ &> /dev/null


### PR DESCRIPTION
After the commit 0a9cc80687585597d5606d18e7091d0ab787d860 the script broke in 'Oops! The .gitignore command couldn't be installed, installation failed.'

This PR solves this problem.
