### PR TITLE
Handle 'push [remotename]'

### DIFF
--- a/push
+++ b/push
@@ -26,7 +26,12 @@ remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
 remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3- )
 
 # Push & save output
-push=$(git push --set-upstream $* $remote $remote_branch 2>&1)
+if [ -z $* ]; then
+  args="$remote $remote_branch"
+else
+  args="$*"
+fi
+push=$(git push --set-upstream $args 2>&1)
 exit_code=$?
 
 if [ $exit_code != 0 ]; then


### PR DESCRIPTION
Fixes #54

If no arguments to push specified, substitute `push [remotename] [branchname]` (to compensate in case no upstream is explicitly set)

If arguments to push are specified, just use those!

Thx @jm3 for the testing