### PR TITLE
GitHub Action to release new homebrew versions

### DIFF
--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -1,0 +1,18 @@
+name: Update Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: git-friendly
+          homebrew-tap: git-friendly/homebrew-git-friendly
+          tag-name: ${{ github.event.release.tag_name }}
+          download-url: https://github.com/git-friendly/git-friendly/archive/${{ github.event.release.tag_name }}.tar.gz
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Using https://github.com/marketplace/actions/bump-homebrew-formula

I found a few other similar actions but this one seems solid

I created a COMMITTER_TOKEN that only has `public_repo` permission, but from what I understand, if I give that `push` permission, it can automatically update the Homebrew repo
