### PR TITLE
Add 'worktree' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="https://jamiedubs.com/images/git-friendly/git-friendly-logo.png" width="100%" style="width:100%" />
 
-A collection of shell scripts for making **pulling**, **pushing**, **branching**, **merging**, and **stashing** with Git fast and painless.
+A collection of shell scripts for making **pulling**, **pushing**, **branching**, **merging**, **stashing**, and **worktrees** with Git fast and painless.
 
-Git sometimes requires typing two or three commands just to execute something basic like fetching new code. git-friendly adds a few new commands — `pull`, `push`, `branch`, `merge` and `stash` which:
+Git sometimes requires typing two or three commands just to execute something basic like fetching new code. git-friendly adds a few new commands — `pull`, `push`, `branch`, `merge`, `stash` and `worktree` which:
 
 * does the most useful thing by default; plus
 * **push** copies a GitHub compare URL to your clipboard;
@@ -65,7 +65,7 @@ export PATH=~/dev/git-friendly:$PATH
 
 ## Usage
 
-You now have some awesome new commands: **branch**, **merge**, **pull**, **push** and **stash**:
+You now have some awesome new commands: **branch**, **merge**, **pull**, **push**, **stash** and **worktree**:
 
 ![](https://d3vv6lp55qjaqc.cloudfront.net/items/3S3H2W1l1F3d1m2x3w1U/pull.png)
 
@@ -138,6 +138,20 @@ stash
 stash pop
 ```
 
+### `worktree`
+
+Create and manage Git worktrees with ease. Perfect for working on multiple branches simultaneously without switching contexts. Works great with [Claude Code](https://claude.ai/code) for AI-assisted development across branches.
+
+```sh
+worktree feature-branch  # Create worktree for new/existing branch
+worktree -l              # List all worktrees
+worktree -r path/to/tree # Remove a worktree
+```
+
+* Automatically creates well-named worktree directories (e.g., `repo-name-branch-name`)
+* Detects and uses existing local or remote branches
+* Switches you directly into the new worktree directory
+
 ## Configuration
 
 Change git-friendly behavior using environment variables. For example, add this line to your `~/.bash_profile` to disable running `bundle install` in the `pull` command:
@@ -197,10 +211,11 @@ if type __git_complete &> /dev/null; then
 
   __git_complete branch _branch
   __git_complete merge _git_merge
+  __git_complete worktree _git_worktree
 fi;
 ```
 
-Now typing `branch <tab>` will suggest or autocomplete branches you can checkout to, `branch -d <tab>` branches you can delete and `merge <tab>` branches you can merge.
+Now typing `branch <tab>` will suggest or autocomplete branches you can checkout to, `branch -d <tab>` branches you can delete, `merge <tab>` branches you can merge, and `worktree <tab>` will suggest branches for creating worktrees.
 
 > [!NOTE]
 > You need to call your [git-completion](https://github.com/git/git/blob/0b0cc9f86731f894cff8dd25299a9b38c254569e/contrib/completion/git-completion.bash) script before this snippet.

--- a/worktree
+++ b/worktree
@@ -2,11 +2,11 @@
 #
 # Usage: worktree [branchname]
 # Usage: worktree -l
-# Usage: worktree -r [worktree-path]
+# Usage: worktree -r|-d|-D [worktree-path]
 #
 # Create a new git worktree with a well-named directory and switch to it.
 # If branch already exists locally or remotely, create worktree from that branch.
-# Lists worktrees with -l flag, removes worktree with -r flag.
+# Lists worktrees with -l flag, removes worktree with -r/-d/-D flags.
 #
 
 # Abort if this isn't a git repository
@@ -24,7 +24,7 @@ remove_worktree=
 # Handle flags
 if [ "$1" == "-l" ] || [ "$1" == "--list" ]; then
   list_worktrees=1
-elif [ "$1" == "-r" ] || [ "$1" == "--remove" ]; then
+elif [ "$1" == "-r" ] || [ "$1" == "--remove" ] || [ "$1" == "-d" ] || [ "$1" == "-D" ]; then
   remove_worktree=1
   branch=$2
 fi
@@ -40,7 +40,7 @@ fi
 if [ "$remove_worktree" ]; then
   if [ -z "$branch" ]; then
     echo "${color_error}Error: Specify worktree path to remove${color_reset}"
-    echo "Usage: $(basename $0) -r <worktree-path>"
+    echo "Usage: $(basename $0) -r|-d|-D <worktree-path>"
     exit 1
   fi
   echo "💀  Removing worktree: $branch"
@@ -55,7 +55,7 @@ if [ -z "$branch" ]; then
   echo -e "\nList all worktrees:"
   echo -e "  $(basename $0) -l"
   echo -e "\nRemove a worktree:"
-  echo -e "  $(basename $0) -r <worktree-path>"
+  echo -e "  $(basename $0) -r|-d|-D <worktree-path>"
   echo -e "\nCurrent worktrees:"
   git worktree list
   echo

--- a/worktree
+++ b/worktree
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Usage: worktree [branchname]
+# Usage: worktree -l
+# Usage: worktree -r [worktree-path]
+#
+# Create a new git worktree with a well-named directory and switch to it.
+# If branch already exists locally or remotely, create worktree from that branch.
+# Lists worktrees with -l flag, removes worktree with -r flag.
+#
+
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
+# Colors
+color_error="$(tput sgr 0 1)$(tput setaf 1)"
+color_reset="$(tput sgr0)"
+
+remote="origin"
+branch=$1
+list_worktrees=
+remove_worktree=
+
+# Handle flags
+if [ "$1" == "-l" ] || [ "$1" == "--list" ]; then
+  list_worktrees=1
+elif [ "$1" == "-r" ] || [ "$1" == "--remove" ]; then
+  remove_worktree=1
+  branch=$2
+fi
+
+# List worktrees
+if [ "$list_worktrees" ]; then
+  echo "📚  Current worktrees:"
+  git worktree list
+  exit 0
+fi
+
+# Remove worktree
+if [ "$remove_worktree" ]; then
+  if [ -z "$branch" ]; then
+    echo "${color_error}Error: Specify worktree path to remove${color_reset}"
+    echo "Usage: $(basename $0) -r <worktree-path>"
+    exit 1
+  fi
+  echo "💀  Removing worktree: $branch"
+  git worktree remove "$branch"
+  exit $?
+fi
+
+# If no branch specified, show usage
+if [ -z "$branch" ]; then
+  echo -e "\nCreate a new worktree:"
+  echo -e "  $(basename $0) <branchname>"
+  echo -e "\nList all worktrees:"
+  echo -e "  $(basename $0) -l"
+  echo -e "\nRemove a worktree:"
+  echo -e "  $(basename $0) -r <worktree-path>"
+  echo -e "\nCurrent worktrees:"
+  git worktree list
+  echo
+  exit 0
+fi
+
+# Get the repository name and main worktree directory
+repo_root=$(git rev-parse --show-toplevel)
+repo_name=$(basename "$repo_root")
+parent_dir=$(dirname "$repo_root")
+
+# Check if branch exists locally or remotely
+local_branch_exists=$(git branch --no-color | egrep " $branch\$")
+remote_branch_exists=$(git branch -r --no-color | egrep " $remote/$branch\$")
+
+# Find all remotes that have this branch
+remotes=($(git remote))
+remotes_with_branch=()
+origin_has_branch=
+
+for rem in "${remotes[@]}"; do
+  remote_branch=$(git branch -r --no-color | egrep " $rem/$branch\$")
+  if [ "$remote_branch" ]; then
+    remotes_with_branch=("${remotes_with_branch[@]}" "$rem")
+    if [ "$rem" = "origin" ]; then
+      origin_has_branch=1
+    fi
+  fi
+done
+
+# Determine which remote to use (prefer origin)
+if [ ${#remotes_with_branch[@]} -gt 0 ]; then
+  if [ "$origin_has_branch" = "1" ]; then
+    remote=origin
+  else
+    remote=${remotes_with_branch[0]}
+  fi
+  remote_branch_exists="$remote/$branch"
+fi
+
+# Create worktree directory path
+worktree_dir="${parent_dir}/${repo_name}-${branch}"
+
+# Check if worktree already exists
+if [ -d "$worktree_dir" ]; then
+  echo "👓  Worktree already exists at $worktree_dir, switching to it..."
+  cd "$worktree_dir"
+  exec $SHELL
+  exit 0
+fi
+
+# Create worktree based on branch existence
+if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
+  # Use existing local branch
+  echo "👓  Creating worktree from existing local branch '$branch'..."
+  git worktree add "$worktree_dir" "$branch"
+elif [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
+  # Create from remote branch
+  echo "📡  Creating worktree from remote branch '$remote_branch_exists'..."
+  git worktree add -b "$branch" "$worktree_dir" "$remote_branch_exists"
+else
+  # Create new branch
+  echo "✏️  Creating worktree with new branch '$branch'..."
+  git worktree add -b "$branch" "$worktree_dir"
+fi
+
+# Check if worktree creation succeeded
+if [ $? -eq 0 ]; then
+  echo "🌳  Worktree created at: $worktree_dir"
+  echo "🚀  Switching to new worktree..."
+  cd "$worktree_dir"
+  exec $SHELL
+else
+  echo "${color_error}Failed to create worktree${color_reset}"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
`worktree` command to quickly make, manage and remove git worktrees

I've been using worktrees a ton lately thanks to [Claude Code](https://claude.com/product/claude-code). works pretty well, but interacting with worktres is also a lengthy command to do correctly and I never remember the right syntax. very git-friendly style problem

worktrees are great for running parallel Claude Code session from a single git checkout: https://docs.claude.com/en/docs/claude-code/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees

new `workflow` command:

- makes & tears down consistently-named worktrees `$dirname-$branch`
- autocomplete branch name (in .profile)
- make worktree from remote branch
- updated README

