### PR TITLE
Improve compare URL copying in "push"

### DIFF
--- a/push
+++ b/push
@@ -45,42 +45,29 @@ elif echo $push | grep "Everything up-to-date" >/dev/null; then
   exit 0
 fi
 
-# Parse relevant commit refs and let user know what we did
-# 1st-time push to new branch gets special treatment
+# Extract commit hash range and display what we pushed
+commit_range=$(echo "$push" | grep -oE '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1)
+
 if echo $push | grep "\[new branch\]" >/dev/null; then
-  parent=$(get_parent)
-  if [ -z "$parent" ]; then
-    parent="main"
-  fi
-  refs="$parent...$branch"
   echo "🚀  Pushed a new branch '$branch' remotely"
 else
-  # Extract commit hash range from push output (e.g. "abc1234..def5678")
-  commit_range=$(echo "$push" | grep -oE '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1)
-
-  if [ ! -z "$commit_range" ] && { [ "$branch" = "main" ] || [ "$branch" = "master" ]; }; then
-    # Pushing to default branch: use commit hashes (branch-name compare is meaningless)
-    refs="$commit_range"
-  else
-    # Feature branch: use branch-name compare (more readable)
-    parent=$(get_parent)
-    if [ -z "$parent" ]; then
-      parent="main"
-    fi
-    refs="$parent...$branch"
-  fi
-
   echo "🚀  Pushed:"
-  # Show just the commit ref line, filtering out noisy remote: messages
-  commit_line=$(echo "$push" | grep -E '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1)
-  if [ ! -z "$commit_line" ]; then
-    echo "$commit_line" | sed 's/^[ \t]*/   /'
+  if [ ! -z "$commit_range" ]; then
+    echo "$push" | grep -E '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1 | sed 's/^[ \t]*/   /'
   else
     echo "$push" | grep -v '^remote:' | grep -v '^To ' | head -5
   fi
 fi
 
-# Parse output into a GitHub URL
+# Build compare refs: commit hashes for main/master, branch names for feature branches
+if [ ! -z "$commit_range" ] && { [ "$branch" = "main" ] || [ "$branch" = "master" ]; }; then
+  refs="$commit_range"
+else
+  parent=$(get_parent)
+  refs="${parent:-main}...$branch"
+fi
+
+# Build GitHub URL: prefer PR URL > compare URL
 remote_url=$(git remote show $remote -n | grep Push | awk '{ print $3 }')
 
 if [[ "$remote_url" =~ "github.com" ]]; then
@@ -94,26 +81,17 @@ if [[ "$remote_url" =~ "github.com" ]]; then
 
   repo_name=$(echo $remote_url | sed $regEx)
 
-  # Try to find the most contextually relevant URL:
-  # 1. GitHub's suggested PR creation URL (new branches)
-  # 2. Existing PR URL via gh CLI (feature branches with open PRs)
-  # 3. Compare URL (commit hashes for main, branch names for features)
-  github_pr_url=$(echo "$push" | grep -o 'https://github\.com/[^/]*/[^/]*/pull/new/[^[:space:]]*' | head -1)
+  # Check for PR URL from GitHub's push output, then from gh CLI
+  github_url=$(echo "$push" | grep -o 'https://github\.com/[^/]*/[^/]*/pull/new/[^[:space:]]*' | head -1)
 
-  if [ -z "$github_pr_url" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ] && command -v gh >/dev/null 2>&1; then
+  if [ -z "$github_url" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ] && command -v gh >/dev/null 2>&1; then
     pr_number=$(gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null)
     if [ ! -z "$pr_number" ] && [ "$pr_number" != "null" ]; then
-      github_pr_url="$url$repo_name/pull/$pr_number"
+      github_url="$url$repo_name/pull/$pr_number"
     fi
   fi
 
-  compare_url="$url$repo_name/compare/$refs"
-
-  if [ ! -z "$github_pr_url" ]; then
-    github_url="$github_pr_url"
-  else
-    github_url="$compare_url"
-  fi
+  github_url="${github_url:-$url$repo_name/compare/$refs}"
 
   if [ "$GIT_FRIENDLY_NO_COPY_URL_AFTER_PUSH" != "true" ]; then
     copied="\nCopied URL to clipboard:"

--- a/push
+++ b/push
@@ -55,12 +55,32 @@ if echo $push | grep "\[new branch\]" >/dev/null; then
   refs="$parent...$branch"
   echo "🚀  Pushed a new branch '$branch' remotely"
 else
-  refs=$(echo $push | awk '{ print $3}' | sed 's/\.\./\.\.\./')
+  # Extract commit hash range from push output (e.g. "abc1234..def5678")
+  commit_range=$(echo "$push" | grep -oE '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1)
+
+  if [ ! -z "$commit_range" ] && { [ "$branch" = "main" ] || [ "$branch" = "master" ]; }; then
+    # Pushing to default branch: use commit hashes (branch-name compare is meaningless)
+    refs="$commit_range"
+  else
+    # Feature branch: use branch-name compare (more readable)
+    parent=$(get_parent)
+    if [ -z "$parent" ]; then
+      parent="main"
+    fi
+    refs="$parent...$branch"
+  fi
+
   echo "🚀  Pushed:"
-  echo "$push"
+  # Show just the commit ref line, filtering out noisy remote: messages
+  commit_line=$(echo "$push" | grep -E '[a-f0-9]{7,}\.\.[a-f0-9]{7,}' | head -1)
+  if [ ! -z "$commit_line" ]; then
+    echo "$commit_line" | sed 's/^[ \t]*/   /'
+  else
+    echo "$push" | grep -v '^remote:' | grep -v '^To ' | head -5
+  fi
 fi
 
-# Parse output into a GitHub compare URL
+# Parse output into a GitHub URL
 remote_url=$(git remote show $remote -n | grep Push | awk '{ print $3 }')
 
 if [[ "$remote_url" =~ "github.com" ]]; then
@@ -73,9 +93,30 @@ if [[ "$remote_url" =~ "github.com" ]]; then
   fi
 
   repo_name=$(echo $remote_url | sed $regEx)
-  github_url="$url$repo_name/compare/$refs"
+
+  # Try to find the most contextually relevant URL:
+  # 1. GitHub's suggested PR creation URL (new branches)
+  # 2. Existing PR URL via gh CLI (feature branches with open PRs)
+  # 3. Compare URL (commit hashes for main, branch names for features)
+  github_pr_url=$(echo "$push" | grep -o 'https://github\.com/[^/]*/[^/]*/pull/new/[^[:space:]]*' | head -1)
+
+  if [ -z "$github_pr_url" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ] && command -v gh >/dev/null 2>&1; then
+    pr_number=$(gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null)
+    if [ ! -z "$pr_number" ] && [ "$pr_number" != "null" ]; then
+      github_pr_url="$url$repo_name/pull/$pr_number"
+    fi
+  fi
+
+  compare_url="$url$repo_name/compare/$refs"
+
+  if [ ! -z "$github_pr_url" ]; then
+    github_url="$github_pr_url"
+  else
+    github_url="$compare_url"
+  fi
+
   if [ "$GIT_FRIENDLY_NO_COPY_URL_AFTER_PUSH" != "true" ]; then
-    copied="\nCompare URL copied to clipboard:"
+    copied="\nCopied URL to clipboard:"
     which pbcopy >&/dev/null && echo $github_url | pbcopy && echo -e "$copied"
     which xclip >&/dev/null && echo $github_url | xclip -selection clipboard && echo -e "$copied"
   fi


### PR DESCRIPTION
fix broken compare URLs when pushing to main/master, and copy the most relevant URL to clipboard instead of always using a compare URL. e.g. use a GitHub PR URL instead if applicable

The old ref parser `(echo $push | awk '{print $3}')` flattened the multiline push output, so the 3rd field was often wrong — especially when GitHub includes remote: messages (dependabot warnings, branch protection notices, etc). This caused two failure modes when pushing to main/master:

  - compare/main...main — a self-comparison that shows nothing
  - compare/some-stale-branch...main — get_parent() returns an unrelated branch name

  Example broken URLs:

  ```
  # Pushing to main, repo has dependabot warnings:
  https://github.com/org/repo/compare/main...main              ← useless
  https://github.com/org/repo/compare/old-feature-branch...main ← wrong branch
```

changes:

  - When pushing to main/master, use commit hashes directly → compare/abc1234..def5678
  - When pushing a feature branch, keep readable compare/main...my-feature
  - Pick up GitHub's suggested pull/new/ URL for first-time branch pushes
  - Look up existing PR URL via gh CLI for feature branches with open PRs
  - Copy the most relevant URL: PR URL > compare URL
  - Filter remote: messages from displayed output (dependabot warnings, etc)

  Example fixed URLs:
```
# Pushing to main — now shows the actual commit diff:
https://github.com/org/repo/compare/9b84ef2..30a191d
```

```
# Pushing a new feature branch — PR creation link:
https://github.com/org/repo/pull/new/my-feature
```

```
# Pushing to feature branch with existing PR — PR link:
https://github.com/org/repo/pull/123
```

```
# Pushing to feature branch, no PR — readable compare:
https://github.com/org/repo/compare/main...my-feature
```