### PR TITLE
Modernize git invocations & fix a few bugs along the way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
           stash push -m "my stash message"
           stash list | grep -q "my stash message"
           stash pop
+          # leave a clean working tree so later tests can rely on it
+          git checkout -- file.txt
 
       - name: Test pull - basic
         run: |
@@ -220,3 +222,110 @@ jobs:
           merge merge-me
           [ -f merge.txt ]
           branch -d merge-me
+
+      - name: Test branch - nonexistent delete propagates failure
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          # `branch -d` on a nonexistent branch must exit non-zero
+          ! branch -d definitely-no-such-branch 2>/dev/null
+
+      - name: Test branch - name with slash
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          branch feature/has-slash
+          [ "$(git branch --show-current)" = "feature/has-slash" ]
+          branch main
+          git branch -D feature/has-slash
+
+      - name: Test detached HEAD - pull/push/merge fail cleanly
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          git checkout main
+          git checkout --detach HEAD
+          ! pull 2>/dev/null
+          ! push 2>/dev/null
+          ! merge main 2>/dev/null
+          git checkout main
+
+      - name: Test pull - skips pop when nothing was stashed
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/other-clone
+          echo "pop test" >> remote.txt
+          git add remote.txt
+          git commit -m "Pop test change"
+          git push origin main
+
+          cd /tmp/test-repo
+          # Clean working tree — pull must not run `git stash pop`
+          out=$(pull 2>&1)
+          echo "$out" | grep -q "Popping stash" && exit 1
+          echo "$out" | grep -q "🦄  Done"
+
+      - name: Test pull - pop runs exactly once when something was stashed
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/other-clone
+          echo "another pop" >> remote.txt
+          git add remote.txt
+          git commit -m "Another pop"
+          git push origin main
+
+          cd /tmp/test-repo
+          echo "untracked wip" > pop-wip.txt
+          out=$(pull 2>&1)
+          pops=$(echo "$out" | grep -c "Popping stash")
+          [ "$pops" = "1" ]
+          [ -f pop-wip.txt ]
+          rm -f pop-wip.txt
+
+      - name: Test pull - has_changed only fires install hooks on actual change
+        run: |
+          export PATH="$PWD:$PATH"
+
+          # Add a yarn.lock + package.json on the remote — first pull should set up the repo
+          cd /tmp/other-clone
+          echo '{}' > package.json
+          : > yarn.lock
+          git add package.json yarn.lock
+          git commit -m "Add JS lockfile"
+          git push origin main
+
+          cd /tmp/test-repo
+          pull >/dev/null 2>&1
+
+          # Push an unrelated change; pull must NOT re-run yarn install
+          cd /tmp/other-clone
+          echo "unrelated" > unrelated.txt
+          git add unrelated.txt
+          git commit -m "Unrelated change"
+          git push origin main
+
+          cd /tmp/test-repo
+          out=$(pull 2>&1)
+          echo "$out" | grep -q "Installing packages with yarn" && {
+            echo "BUG: yarn install fired without lockfile change"
+            exit 1
+          }
+          true
+
+      - name: Test push - passthrough flag (--force-with-lease)
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          echo "force test" > force.txt
+          git add force.txt
+          git commit -m "Force test"
+          push --force-with-lease
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck -S warning branch merge pull push stash install.sh

--- a/branch
+++ b/branch
@@ -47,7 +47,7 @@ fi
 
 # Switch to the previous branch
 if [ "$branch" == "-" ]; then
-  git checkout -
+  git switch -
   exit 0
 fi
 
@@ -59,14 +59,14 @@ if [ "$delete" ]; then
 fi
 
 # Otherwise we're either switching to an existing branch or creating a branch
-local_branch_exists=$(git branch --no-color | egrep " $branch\$")
-remote_branch_exists=$(git branch -r --no-color | egrep " $remote/$branch\$")
+local_branch_exists=$(git branch --no-color | grep -E " $branch\$")
+remote_branch_exists=$(git branch -r --no-color | grep -E " $remote/$branch\$")
 remotes=($(git remote))
 remotes_with_branch=()
 origin_has_branch=
 
 for remote in "${remotes[@]}"; do
-  remote_branch_exists=$(git branch -r --no-color | egrep " $remote/$branch\$")
+  remote_branch_exists=$(git branch -r --no-color | grep -E " $remote/$branch\$")
   if [ "$remote_branch_exists" ]; then
     remotes_with_branch=("${remotes_with_branch[@]}" "$remote")
     if [ "$remote" = "origin" ]; then
@@ -90,7 +90,7 @@ fi
 # If local branch exists already, just switch to it
 if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
   echo "👓  Switching to existing local branch..."
-  git checkout $branch
+  git switch $branch
 
   # Track remote branch if not already
   if [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
@@ -105,12 +105,12 @@ if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
 # If remote exists, create a local branch that tracks the remote
 elif [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
   echo "📡  Tracking existing remote branch '$remote_branch_exists'..."
-  git checkout -b $branch --track $remote/$branch
+  git switch -c $branch --track $remote/$branch
 
 # Otherwise create a new local branch
 else
   echo "✏️  Creating new local branch..."
-  git checkout -b $branch --no-track
+  git switch -c $branch --no-track
 fi
 
 exit 0

--- a/branch
+++ b/branch
@@ -153,7 +153,10 @@ local_branch_exists=
 git show-ref --verify --quiet "refs/heads/$branch" && local_branch_exists=1
 
 remote_branch_exists=
-remotes=($(git remote))
+remotes=()
+while IFS= read -r line; do
+  remotes+=("$line")
+done < <(git remote)
 remotes_with_branch=()
 origin_has_branch=
 

--- a/branch
+++ b/branch
@@ -144,7 +144,7 @@ if [ "$delete" ]; then
   else
     echo "💀  Removing local branch..."
   fi
-  git branch "$delete" "${branches[@]}"
+  git branch "$delete" "${branches[@]}" || exit $?
   exit 0
 fi
 
@@ -179,28 +179,28 @@ if [ ${#remotes_with_branch[@]} -gt 0 ]; then
 fi
 
 # If local branch exists already, just switch to it
-if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
+if [ -n "$local_branch_exists" ]; then
   echo "👓  Switching to existing local branch..."
-  git switch $branch
+  git switch "$branch"
 
   # Track remote branch if not already
-  if [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
+  if [ -n "$remote_branch_exists" ]; then
     tracking=$(git rev-parse --abbrev-ref --symbolic-full-name "$branch@{upstream}" 2>/dev/null)
     if [[ "$tracking" != "$remote"/* ]]; then
       echo "⚒️  Your local branch is not tracking the corresponding remote branch, fixing..."
-      git branch --set-upstream-to=$remote/$branch $branch
+      git branch --set-upstream-to="$remote/$branch" "$branch"
     fi
   fi
 
 # If remote exists, create a local branch that tracks the remote
-elif [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
+elif [ -n "$remote_branch_exists" ]; then
   echo "📡  Tracking existing remote branch '$remote_branch_exists'..."
-  git switch -c $branch --track $remote/$branch
+  git switch -c "$branch" --track "$remote/$branch"
 
 # Otherwise create a new local branch
 else
   echo "✏️  Creating new local branch..."
-  git switch -c $branch --no-track
+  git switch -c "$branch" --no-track
 fi
 
 exit 0

--- a/branch
+++ b/branch
@@ -149,16 +149,17 @@ if [ "$delete" ]; then
 fi
 
 # Otherwise we're either switching to an existing branch or creating a branch
-local_branch_exists=$(git branch --no-color | grep -E " $branch\$")
-remote_branch_exists=$(git branch -r --no-color | grep -E " $remote/$branch\$")
+local_branch_exists=
+git show-ref --verify --quiet "refs/heads/$branch" && local_branch_exists=1
+
+remote_branch_exists=
 remotes=($(git remote))
 remotes_with_branch=()
 origin_has_branch=
 
 for remote in "${remotes[@]}"; do
-  remote_branch_exists=$(git branch -r --no-color | grep -E " $remote/$branch\$")
-  if [ "$remote_branch_exists" ]; then
-    remotes_with_branch=("${remotes_with_branch[@]}" "$remote")
+  if git show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
+    remotes_with_branch+=("$remote")
     if [ "$remote" = "origin" ]; then
       origin_has_branch=1
     fi
@@ -184,9 +185,8 @@ if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
 
   # Track remote branch if not already
   if [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
-    tracking=$(git branch -vv | grep "*" | awk '{ print $4 '})
-    # echo "Remote branch exists. Local branch is tracking: $tracking"
-    if [[ ! "$tracking" =~ "$remote" ]]; then
+    tracking=$(git rev-parse --abbrev-ref --symbolic-full-name "$branch@{upstream}" 2>/dev/null)
+    if [[ "$tracking" != "$remote"/* ]]; then
       echo "⚒️  Your local branch is not tracking the corresponding remote branch, fixing..."
       git branch --set-upstream-to=$remote/$branch $branch
     fi

--- a/branch
+++ b/branch
@@ -67,7 +67,7 @@ if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
 fi
 
 # If no branch specified (or -r), list branches
-if [ -z $branch ] || [ $branch == "-r" ]; then
+if [ -z "$branch" ] || [ "$branch" = "-r" ]; then
   echo
   # Color scheme (matches git branch -vvv defaults)
   esc_green="$(tput setaf 2)"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ FILES=(branch merge pull push stash)
 mkdir -p ${dest}
 
 # Download all scripts
-for s in ${FILES[*]}; do
+for s in "${FILES[@]}"; do
   curl -fsSL -o "${dest}/${s}" "https://raw.githubusercontent.com/git-friendly/git-friendly/main/${s}"
   if [ ! -f "${dest}/${s}" ]; then
     echo

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,8 @@ mkdir -p ${dest}
 
 # Download all scripts
 for s in ${FILES[*]}; do
-  curl -sS -o ${dest}/${s} https://raw.githubusercontent.com/git-friendly/git-friendly/main/${s}
-  if [ ! -f ${dest}/${s} ]; then
+  curl -fsSL -o "${dest}/${s}" "https://raw.githubusercontent.com/git-friendly/git-friendly/main/${s}"
+  if [ ! -f "${dest}/${s}" ]; then
     echo
     echo "Oops! The '${s}' command cannot be copied to ${dest}, installation failed."
     echo "Try to rerun with sudo or specify a custom directory, see for details:"

--- a/merge
+++ b/merge
@@ -8,7 +8,7 @@
 
 remote="origin"
 branch=$1
-current_branch=$(git branch 2>/dev/null | grep -e ^* | tr -d \*)
+current_branch=$(git branch --show-current)
 
 if [ -z $branch ]; then
   echo "Usage: $0 [branchname]"
@@ -20,18 +20,18 @@ git rev-parse --is-inside-work-tree >/dev/null || exit $?
 
 # If there is a remote version of this branch, rebase onto current_branch first
 # If there's a remote (public) branch, we do not want to be rewriting histories
-tracking=$(git branch -vv | egrep "^\*" | awk '{ print $4 '})
+tracking=$(git branch -vv | grep -E "^\*" | awk '{ print $4 '})
 echo "tracking=$tracking"
 if [[ ! "$tracking" =~ "$remote" ]]; then
   echo "⚒  Local-only branch, rebasing $branch onto $current_branch first..."
-  git checkout $branch
+  git switch $branch
   git rebase $current_branch || exit 1
 else
   echo "📡  This branch exists remotely, not rebasing"
 fi
 
 echo "✂️  Merge $branch into $current_branch"
-git checkout $current_branch
+git switch $current_branch
 git merge $branch || exit 1
 
 echo

--- a/merge
+++ b/merge
@@ -8,15 +8,20 @@
 
 remote="origin"
 branch=$1
-current_branch=$(git branch --show-current)
 
-if [ -z $branch ]; then
+if [ -z "$branch" ]; then
   echo "Usage: $0 [branchname]"
   exit 1
 fi
 
 # Abort if this isn't a git repository
 git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
+current_branch=$(git branch --show-current)
+if [ -z "$current_branch" ]; then
+  echo "❌  You're not on a branch (detached HEAD). Check out a branch first." >&2
+  exit 1
+fi
 
 # If there is a remote version of this branch, rebase onto current_branch first
 # If there's a remote (public) branch, we do not want to be rewriting histories

--- a/merge
+++ b/merge
@@ -20,9 +20,8 @@ git rev-parse --is-inside-work-tree >/dev/null || exit $?
 
 # If there is a remote version of this branch, rebase onto current_branch first
 # If there's a remote (public) branch, we do not want to be rewriting histories
-tracking=$(git branch -vv | grep -E "^\*" | awk '{ print $4 '})
-echo "tracking=$tracking"
-if [[ ! "$tracking" =~ "$remote" ]]; then
+tracking=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null)
+if [[ "$tracking" != "$remote"/* ]]; then
   echo "⚒  Local-only branch, rebasing $branch onto $current_branch first..."
   git switch $branch
   git rebase $current_branch || exit 1

--- a/pull
+++ b/pull
@@ -80,7 +80,7 @@ has_changed() {
   return 1
 }
 
-branch=$(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') || exit $?
+branch=$(git branch --show-current) || exit $?
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
 remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3-)

--- a/pull
+++ b/pull
@@ -65,16 +65,12 @@ reset_dir() {
   cd "$current_dir"
 }
 
-# Test wether a file has changed
+# Test whether a file has changed since the pre-pull HEAD.
 # $1 - filename
 has_changed() {
-  # store changed files for install check (
-  # ORIG_HEAD is last value of HEAD before pull
+  # ORIG_HEAD is the value of HEAD before the pull.
   changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD 2>/dev/null)"
-  if $(echo "$changed_files" | grep --quiet "$1"); then
-    return 0
-  fi
-  return 1
+  echo "$changed_files" | grep --quiet "$1"
 }
 
 branch=$(git branch --show-current) || exit $?

--- a/pull
+++ b/pull
@@ -19,7 +19,7 @@ base_dir=$(git rev-parse --show-cdup)
 
 # Pop any stashed changes
 unstash() {
-  if [[ ! "$stash" =~ "No local changes to save" ]]; then
+  if [ -n "$stashed" ]; then
     echo
     echo "🍯  Popping stash..."
     git stash pop
@@ -37,10 +37,7 @@ rollback() {
 # Test whether a command exists
 # $1 - cmd to test
 cmd_exists() {
-  if which $1 >/dev/null 2>&1; then
-    return 0
-  fi
-  return 1
+  command -v "$1" >/dev/null 2>&1
 }
 
 # Test whether a file exists
@@ -81,12 +78,22 @@ has_changed() {
 }
 
 branch=$(git branch --show-current) || exit $?
+if [ -z "$branch" ]; then
+  echo "${color_error}❌  You're not on a branch (detached HEAD). Check out a branch first.${color_reset}" >&2
+  exit 1
+fi
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
 remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3-)
 
-# Stash any local changes, including untracked files
-stash=$(git stash --include-untracked)
+# Stash any local changes, including untracked files.
+# Compare refs/stash before/after to know if anything was actually stashed —
+# more robust than parsing the human-readable output (which is localized).
+stash_before=$(git rev-parse --verify --quiet refs/stash || true)
+git stash --include-untracked
+stash_after=$(git rev-parse --verify --quiet refs/stash || true)
+stashed=
+[ "$stash_before" != "$stash_after" ] && stashed=1
 
 # Fetch all branches (and prune stale ones) so remote-tracking refs
 # stay complete — `git pull <remote> <branch>` alone only updates the

--- a/pull
+++ b/pull
@@ -54,7 +54,7 @@ file_exists() {
 change_dir() {
   file=$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep "$1")
   if [[ -e "./$base_dir$file" ]]; then
-    cd $(dirname "./$base_dir$file")
+    cd "$(dirname "./$base_dir$file")" || return 1
     return 0
   fi
   return 1
@@ -62,7 +62,7 @@ change_dir() {
 
 # Go back to
 reset_dir() {
-  cd "$current_dir"
+  cd "$current_dir" || return 1
 }
 
 # Test whether a file has changed since the pre-pull HEAD.

--- a/push
+++ b/push
@@ -23,7 +23,7 @@ color_error="$(tput sgr 0 1)$(tput setaf 1)"
 color_reset="$(tput sgr0)"
 
 # TODO DRY this b/w pull and push
-branch=$(git branch --no-color 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') || exit $?
+branch=$(git branch --show-current) || exit $?
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
 remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3-)

--- a/push
+++ b/push
@@ -15,7 +15,7 @@ git rev-parse --is-inside-work-tree >/dev/null || exit $?
 # Get parent branch
 # https://stackoverflow.com/a/17843908/1973105
 function get_parent() {
-  git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'
+  git show-branch | grep -F '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'
 }
 
 # Colors
@@ -74,7 +74,7 @@ fi
 # Build GitHub URL: prefer PR URL > compare URL
 remote_url=$(git remote get-url --push $remote)
 
-if [[ "$remote_url" =~ "github.com" ]]; then
+if [[ "$remote_url" =~ github\.com ]]; then
 
   if [[ ${remote_url:0:4} == "git@" ]]; then
     regEx='s/.*\:\(.*\)\.git/\1/'

--- a/push
+++ b/push
@@ -68,7 +68,7 @@ else
 fi
 
 # Build GitHub URL: prefer PR URL > compare URL
-remote_url=$(git remote show $remote -n | grep Push | awk '{ print $3 }')
+remote_url=$(git remote get-url --push $remote)
 
 if [[ "$remote_url" =~ "github.com" ]]; then
 

--- a/push
+++ b/push
@@ -24,17 +24,21 @@ color_reset="$(tput sgr0)"
 
 # TODO DRY this b/w pull and push
 branch=$(git branch --show-current) || exit $?
+if [ -z "$branch" ]; then
+  echo "${color_error}❌  You're not on a branch (detached HEAD). Check out a branch first.${color_reset}" >&2
+  exit 1
+fi
 default_remote="origin"
 remote=$(git config "branch.${branch}.remote" || echo "$default_remote")
 remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branch") | cut -d/ -f3-)
 
 # Push & save output
-if [ -z $* ]; then
-  args="$remote $remote_branch"
+if [ $# -eq 0 ]; then
+  args=("$remote" "$remote_branch")
 else
-  args="$*"
+  args=("$@")
 fi
-push=$(git push --set-upstream $args 2>&1)
+push=$(git push --set-upstream "${args[@]}" 2>&1)
 exit_code=$?
 
 if [ $exit_code != 0 ]; then
@@ -95,8 +99,8 @@ if [[ "$remote_url" =~ "github.com" ]]; then
 
   if [ "$GIT_FRIENDLY_NO_COPY_URL_AFTER_PUSH" != "true" ]; then
     copied="\nCopied URL to clipboard:"
-    which pbcopy >&/dev/null && echo $github_url | pbcopy && echo -e "$copied"
-    which xclip >&/dev/null && echo $github_url | xclip -selection clipboard && echo -e "$copied"
+    command -v pbcopy >/dev/null 2>&1 && echo $github_url | pbcopy && echo -e "$copied"
+    command -v xclip >/dev/null 2>&1 && echo $github_url | xclip -selection clipboard && echo -e "$copied"
   fi
 
   echo $github_url


### PR DESCRIPTION
quick swap of legacy git incantations across the 5 scripts for modern equivalents:

- git switch / git switch -c instead of git checkout / -b for branch switching
- grep -E instead of egrep (deprecated since 2007 lol)
- git branch --show-current instead of `git branch | sed`-style parsing
- git show-ref --verify --quiet for branch existence checks (no more grepping branch output)
- git rev-parse --abbrev-ref "$b@{upstream}" for tracking detection (was awk-ing git branch -vv)
- git remote get-url --push for the remote URL in push
- bug: branch -d/-D on a nonexistent branch was silently exit 0 — now propagates git's exit code
- bug: push had `[ -z $* ]` which is a glob/word-splitting bug — switched to `$#` + an args array
- bug: pull's stash detection matched the literal english string "No local changes to save", so non-en-US locales would have the wrong stash popped — now compares refs/stash before and after
- bug: pull, push, merge now detect detached HEAD up-front instead of falling through to raw git errors
- bug: install.sh added -fL to curl so a 404 doesn't silently land an HTML error page in the script file
- cleanup: pull, push swapped deprecated `which` for `command -v`; branch dropped redundant `[ -n "$x" ] && [ ! "$x" == '' ]` patterns and quoted some loose vars

git 2.23 (Aug 2019) becomes the new floor, which feels safe.

to test:
- usual flows (`branch foo`, `branch -`, `pull`, `push`) work as before
- `branch -d definitely-no-such-branch` now exits non-zero (was 0)
- on detached HEAD, `pull` / `push` / `merge main` print a friendly error and exit non-zero
- existing CI green (25/25). new regression tests live in the stacked PR (add-test-coverage)