### PR TITLE
Pull: don't run npm install in repos with another lockfile

### DIFF
--- a/pull
+++ b/pull
@@ -116,58 +116,48 @@ if [ "$GIT_FRIENDLY_NO_BUNDLE" != "true" ]; then
   fi
 fi
 
-# Install Node.js packages with Yarn
-yarned=0
-if [ "$GIT_FRIENDLY_NO_YARN" != "true" ]; then
-  if file_exists 'yarn.lock' && (has_changed 'yarn.lock' || has_changed 'package.json'); then
-    change_dir 'yarn.lock' || change_dir 'package.json'
-    if cmd_exists 'yarn'; then
-      echo
-      echo '⚔  Installing packages with yarn...'
-      yarn install
-      yarned=1
-    fi
-    reset_dir
-  fi
+# JS packages — each block fires when its own lockfile is present;
+# npm is the fallback used only when no JS lockfile exists at all.
+has_js_lockfile() {
+  file_exists 'yarn.lock' || file_exists 'pnpm-lock.yaml' \
+    || file_exists 'bun.lock' || file_exists 'bun.lockb'
+}
+
+if [ "$GIT_FRIENDLY_NO_YARN" != "true" ] && cmd_exists 'yarn' \
+   && file_exists 'yarn.lock' && (has_changed 'yarn.lock' || has_changed 'package.json'); then
+  change_dir 'yarn.lock' || change_dir 'package.json'
+  echo
+  echo '⚔  Installing packages with yarn...'
+  yarn install
+  reset_dir
 fi
 
-# Install node.js packages with pnpm
-if [ "$GIT_FRIENDLY_NO_PNPM" != "true" ]; then
-  if file_exists 'pnpm-lock.yaml' && (has_changed 'pnpm-lock.yaml' || has_changed 'package.json') && [ $yarned -eq 0 ]; then
-    change_dir 'pnpm-lock.yaml' || change_dir 'package.json'
-    if cmd_exists 'pnpm'; then
-      echo
-      echo '⚔  Installing packages with pnpm...'
-      pnpm install
-      yarned=1
-    fi
-    reset_dir
-  fi
+if [ "$GIT_FRIENDLY_NO_PNPM" != "true" ] && cmd_exists 'pnpm' \
+   && file_exists 'pnpm-lock.yaml' && (has_changed 'pnpm-lock.yaml' || has_changed 'package.json'); then
+  change_dir 'pnpm-lock.yaml' || change_dir 'package.json'
+  echo
+  echo '⚔  Installing packages with pnpm...'
+  pnpm install
+  reset_dir
 fi
 
-# Install Node.js packages with npm
-if [ "$GIT_FRIENDLY_NO_NPM" != "true" ]; then
-  if cmd_exists 'npm' && has_changed 'package.json' && [ $yarned -eq 0 ]; then
-    echo
-    echo '⚔  Installing packages with npm...'
-    change_dir 'package.json'
-    npm install
-    reset_dir
-  fi
+if [ "$GIT_FRIENDLY_NO_BUN" != "true" ] && cmd_exists 'bun' \
+   && (file_exists 'bun.lock' || file_exists 'bun.lockb') \
+   && (has_changed 'bun.lock' || has_changed 'bun.lockb' || has_changed 'package.json'); then
+  change_dir 'bun.lock' || change_dir 'bun.lockb' || change_dir 'package.json'
+  echo
+  echo '⚔  Installing packages with bun...'
+  bun install
+  reset_dir
 fi
 
-# Install packages with bun
-if [ "$GIT_FRIENDLY_NO_BUN" != "true" ]; then
-  if (file_exists 'bun.lock' || file_exists 'bun.lockb') && (has_changed 'bun.lock' || has_changed 'bun.lockb' || has_changed 'package.json') && [ $yarned -eq 0 ]; then
-    change_dir 'bun.lock' || change_dir 'bun.lockb' || change_dir 'package.json'
-    if cmd_exists 'bun'; then
-      echo
-      echo '⚔  Installing packages with bun...'
-      bun install
-      yarned=1
-    fi
-    reset_dir
-  fi
+if [ "$GIT_FRIENDLY_NO_NPM" != "true" ] && cmd_exists 'npm' \
+   && has_changed 'package.json' && ! has_js_lockfile; then
+  change_dir 'package.json'
+  echo
+  echo '⚔  Installing packages with npm...'
+  npm install
+  reset_dir
 fi
 
 # Install Composer packages


### PR DESCRIPTION
fixes a bug where `pull` runs `npm install` in bun/pnpm/yarn repos when package.json changed — leaving behind a stray `package-lock.json` and an npm-resolved `node_modules` next to the real lockfile.

- npm is now a true last-resort: only runs when no `yarn.lock` / `pnpm-lock.yaml` / `bun.lock` / `bun.lockb` is present
- drop the `yarned` gate variable; each block stands on its own lockfile check
- reorder so npm runs last, after yarn/pnpm/bun

to test:
- in a bun repo with a recently-changed package.json, run `pull` → see "Installing packages with bun…" only, no npm
- in a plain `package.json`-only repo (no lockfile), `pull` still runs `npm install`