### PR TITLE
branch: let -d/-D delete multiple branches

### DIFF
--- a/branch
+++ b/branch
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Usage: branch [branchname]
-# Usage: branch [-D] [-d] [branchname]
+# Usage: branch [-D|-d] <branchname>...
 # Usage: branch -
 #
 #
@@ -18,24 +18,36 @@ git rev-parse --is-inside-work-tree >/dev/null || exit $?
 remote="origin"
 branch=$1
 delete=
+branches=()
 
 # Colors
 color_bold="$(tput bold)"
 color_dim="$(tput dim)"
 color_reset="$(tput sgr0)"
 
-# If deleting a branch, stash the flag and branch name to use later
+# If deleting, stash the flag and collect all remaining args as branches to delete
 if [ "$1" == "-d" ] || [ "$1" == "-D" ]; then
   delete=$1
-  branch=$2
+  shift
+  branches=("$@")
+  branch=$1
 fi
 
 # Strip remote prefix (e.g. "origin/foo" → "foo") for autocomplete convenience
-for _r in $(git remote 2>/dev/null); do
+_remotes=$(git remote 2>/dev/null)
+for _r in $_remotes; do
   if [[ "$branch" == "$_r/"* ]]; then
     branch="${branch#"$_r/"}"
     break
   fi
+done
+for i in "${!branches[@]}"; do
+  for _r in $_remotes; do
+    if [[ "${branches[$i]}" == "$_r/"* ]]; then
+      branches[$i]="${branches[$i]#"$_r/"}"
+      break
+    fi
+  done
 done
 
 # Show help
@@ -46,7 +58,7 @@ if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
   echo "    ${cmd}                  List local branches"
   echo "    ${cmd} [name]           Switch to or create a branch"
   echo "    ${cmd} -                Switch to previous branch"
-  echo "    ${cmd} -d|-D <name>     Delete a branch"
+  echo "    ${cmd} -d|-D <name>...  Delete one or more branches"
   echo "    ${cmd} -r               List remote branches"
   echo
   echo "  Automatically tracks a matching remote branch if one exists."
@@ -121,10 +133,18 @@ if [ "$branch" == "-" ]; then
   exit 0
 fi
 
-# Delete branch
+# Delete branch(es)
 if [ "$delete" ]; then
-  echo "💀  Removing local branch..."
-  git branch $delete $branch
+  if [ ${#branches[@]} -eq 0 ]; then
+    echo "Usage: $(basename $0) $delete <name>..." >&2
+    exit 1
+  fi
+  if [ ${#branches[@]} -gt 1 ]; then
+    echo "💀  Removing local branches..."
+  else
+    echo "💀  Removing local branch..."
+  fi
+  git branch "$delete" "${branches[@]}"
   exit 0
 fi
 


### PR DESCRIPTION
extend `branch -d` / `-D` to accept multiple branch names, matching native `git branch` behavior so you can do `branch -d foo bar baz` instead of running it three times.

- collect all args after the flag and pass them through to `git branch`
- remote prefix stripping (e.g. `origin/foo` → `foo`) now applies to each name
- usage/help updated to `<name>...`

to test:
- `branch -d foo bar baz` in a scratch repo deletes all three
- `branch -D origin/foo bar` strips the remote prefix and force-deletes both
- `branch -d <single>` still works as before