### PR TITLE
Pull: actually fetch all remote branches, not just current

### DIFF
--- a/pull
+++ b/pull
@@ -88,8 +88,13 @@ remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branc
 # Stash any local changes, including untracked files
 stash=$(git stash --include-untracked)
 
-# Pull, using rebase if configured
+# Fetch all branches (and prune stale ones) so remote-tracking refs
+# stay complete — `git pull <remote> <branch>` alone only updates the
+# one ref you name.
 echo "🚀  Fetching from $remote..."
+git fetch --prune --jobs=10 "$remote" || rollback $?
+
+# Pull, using rebase if configured
 if [ "$GIT_FRIENDLY_NO_REBASE_ON_PULL" != "true" ]; then
   rebase="--rebase"
 else
@@ -100,10 +105,6 @@ git pull $rebase --recurse-submodules --jobs=10 $remote $remote_branch || rollba
 
 # Pop any stashed changes
 unstash
-
-# Remove old, stale branches
-# This works a lot better than "git pull --prune" for unknown reasons
-git remote prune $remote >/dev/null 2>&1 &
 
 # Bundle em if you got em!
 if [ "$GIT_FRIENDLY_NO_BUNDLE" != "true" ]; then


### PR DESCRIPTION
turns out `pull` was only updating the current branch's remote ref — `git pull <remote> <branch>` with an explicit refspec skips the remote's normal `fetch = +refs/heads/*` config, so other `origin/*` refs went stale until you separately ran `git fetch`. that's why new origin branches sometimes weren't there after a pull.

- run an explicit `git fetch --prune` before the rebase-pull so all remote-tracking branches refresh
- drop the backgrounded `git remote prune` — `--prune` on the fetch handles it synchronously
- scoped to `$remote` (not `--all`) to preserve behavior for repos with multiple remotes

to test:
- in a repo where origin has a brand-new branch you don't have locally, run `./pull` and confirm `git branch -r` now shows it
- delete a branch on origin, run `./pull`, confirm the stale `origin/*` ref is gone