### PR TITLE
pull: run uv sync for Python projects using uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Git sometimes requires typing two or three commands just to execute something ba
 
 * does the most useful thing by default; plus
 * **push** copies a GitHub compare URL to your clipboard;
-* **pull** runs commands like `bundle install`, `npm install`, `yarn install`, `pnpm install` and `composer install` if necessary;
+* **pull** runs commands like `bundle install`, `npm install`, `yarn install`, `pnpm install`, `uv sync` and `composer install` if necessary;
 * **branch** tracks remote branches if they are available;
 * **stash** includes untracked files by default.
 
@@ -119,7 +119,7 @@ merge [name]
 * pull from the remote using rebase;
 * update submodules;
 * pop your stash;
-* run `bundle install`, `npm install`, `yarn install`, `pnpm install` or `composer install` if there are any changes in `Gemfile`, `package.json`, etc.
+* run `bundle install`, `npm install`, `yarn install`, `pnpm install`, `uv sync` or `composer install` if there are any changes in `Gemfile`, `package.json`, `uv.lock`, etc.
 
 ### `push`
 
@@ -155,6 +155,7 @@ Available environment variables:
 | `GIT_FRIENDLY_NO_NPM` | Disables `npm install` | `pull` | `false` |
 | `GIT_FRIENDLY_NO_YARN` | Disables `yarn install` | `pull` | `false` |
 | `GIT_FRIENDLY_NO_PNPM` | Disables `pnpm install` | `pull` | `false` |
+| `GIT_FRIENDLY_NO_UV` | Disables `uv sync` | `pull` | `false` |
 | `GIT_FRIENDLY_NO_REBASE_ON_PULL` | Disables rebasing local commits on top of the updated remote branch | `pull` | `false` |
 | `GIT_FRIENDLY_NO_COPY_URL_AFTER_PUSH` | Disables copying URL to clipboard | `push` | `false` |
 
@@ -165,6 +166,7 @@ Available environment variables:
 * npm (JavaScript)
 * yarn (JavaScript)
 * pnpm (JavaScript)
+* uv (Python)
 
 Support for more is always welcome.
 

--- a/pull
+++ b/pull
@@ -161,6 +161,17 @@ if [ "$GIT_FRIENDLY_NO_NPM" != "true" ] && cmd_exists 'npm' \
   reset_dir
 fi
 
+# Install uv packages (Python). Anchored on uv.lock so we never run uv
+# against a non-uv pyproject.toml (poetry/hatch/pip-tools also use one).
+if [ "$GIT_FRIENDLY_NO_UV" != "true" ] && cmd_exists 'uv' \
+   && file_exists 'uv.lock' && (has_changed 'uv.lock' || has_changed 'pyproject.toml'); then
+  change_dir 'uv.lock' || change_dir 'pyproject.toml'
+  echo
+  echo '⚔  Installing packages with uv...'
+  uv sync
+  reset_dir
+fi
+
 # Install Composer packages
 if [ "$GIT_FRIENDLY_NO_COMPOSER" != "true" ]; then
   if has_changed 'composer.lock'; then


### PR DESCRIPTION
adds uv to the list of package managers pull auto-installs, so python projects using uv get synced after a fetch like the js/ruby/php ones already do.

- runs `uv sync` when `uv.lock` or `pyproject.toml` changes on pull
- anchored on `uv.lock` existing so it never fires against a non-uv `pyproject.toml` (poetry/hatch/pip-tools all use one too)
- opt out with `GIT_FRIENDLY_NO_UV=true`, documented in the readme

to test:
- in a uv repo, pull a commit that touches uv.lock → should print "Installing packages with uv..." and run uv sync
- in a pyproject-only repo with no uv.lock, pull → uv should not run