### PR TITLE
Pull: stop double-fetching submodules

### DIFF
--- a/pull
+++ b/pull
@@ -90,9 +90,10 @@ stash=$(git stash --include-untracked)
 
 # Fetch all branches (and prune stale ones) so remote-tracking refs
 # stay complete — `git pull <remote> <branch>` alone only updates the
-# one ref you name.
+# one ref you name. Skip submodules here; the recursive pull below owns
+# submodule updates, so recursing now just double-fetches them.
 echo "🚀  Fetching from $remote..."
-git fetch --prune --jobs=10 "$remote" || rollback $?
+git fetch --prune --no-recurse-submodules --jobs=10 "$remote" || rollback $?
 
 # Pull, using rebase if configured
 if [ "$GIT_FRIENDLY_NO_REBASE_ON_PULL" != "true" ]; then


### PR DESCRIPTION
the explicit `git fetch` we added in #133 (to keep all branch refs fresh) recurses into submodules, and so does the `git pull --recurse-submodules` right after it — so on a repo with submodules every submodule gets fetched twice on every `pull`. this passes `--no-recurse-submodules` to that first fetch so submodules are only fetched once.

- branch-refresh fetch no longer recurses into submodules
- the recursive pull below still owns submodule updates, so nothing changes functionally

to test:
- in a repo with submodules (e.g. a site with several), run `pull`
- submodules should no longer appear under `🚀 Fetching from origin...` — fetched at most once
- `git submodule status` confirms they land at the right commits