### PR TITLE
Expand CI test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,110 @@ jobs:
           merge merge-me
           [ -f merge.txt ]
           branch -d merge-me
+
+      - name: Test branch - nonexistent delete propagates failure
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          # `branch -d` on a nonexistent branch must exit non-zero
+          ! branch -d definitely-no-such-branch 2>/dev/null
+
+      - name: Test branch - name with slash
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          branch feature/has-slash
+          [ "$(git branch --show-current)" = "feature/has-slash" ]
+          branch main
+          git branch -D feature/has-slash
+
+      - name: Test detached HEAD - pull/push/merge fail cleanly
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          git checkout main
+          git checkout --detach HEAD
+          ! pull 2>/dev/null
+          ! push 2>/dev/null
+          ! merge main 2>/dev/null
+          git checkout main
+
+      - name: Test pull - skips pop when nothing was stashed
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/other-clone
+          echo "pop test" >> remote.txt
+          git add remote.txt
+          git commit -m "Pop test change"
+          git push origin main
+
+          cd /tmp/test-repo
+          # Clean working tree — pull must not run `git stash pop`
+          out=$(pull 2>&1)
+          echo "$out" | grep -q "Popping stash" && exit 1
+          echo "$out" | grep -q "🦄  Done"
+
+      - name: Test pull - pop runs exactly once when something was stashed
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/other-clone
+          echo "another pop" >> remote.txt
+          git add remote.txt
+          git commit -m "Another pop"
+          git push origin main
+
+          cd /tmp/test-repo
+          echo "untracked wip" > pop-wip.txt
+          out=$(pull 2>&1)
+          pops=$(echo "$out" | grep -c "Popping stash")
+          [ "$pops" = "1" ]
+          [ -f pop-wip.txt ]
+          rm -f pop-wip.txt
+
+      - name: Test pull - has_changed only fires install hooks on actual change
+        run: |
+          export PATH="$PWD:$PATH"
+
+          # Add a yarn.lock + package.json on the remote — first pull should set up the repo
+          cd /tmp/other-clone
+          echo '{}' > package.json
+          : > yarn.lock
+          git add package.json yarn.lock
+          git commit -m "Add JS lockfile"
+          git push origin main
+
+          cd /tmp/test-repo
+          pull >/dev/null 2>&1
+
+          # Push an unrelated change; pull must NOT re-run yarn install
+          cd /tmp/other-clone
+          echo "unrelated" > unrelated.txt
+          git add unrelated.txt
+          git commit -m "Unrelated change"
+          git push origin main
+
+          cd /tmp/test-repo
+          out=$(pull 2>&1)
+          echo "$out" | grep -q "Installing packages with yarn" && {
+            echo "BUG: yarn install fired without lockfile change"
+            exit 1
+          }
+          true
+
+      - name: Test push - passthrough flag (--force-with-lease)
+        run: |
+          export PATH="$PWD:$PATH"
+          cd /tmp/test-repo
+          echo "force test" > force.txt
+          git add force.txt
+          git commit -m "Force test"
+          push --force-with-lease
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck -S warning branch merge pull push stash install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
           stash push -m "my stash message"
           stash list | grep -q "my stash message"
           stash pop
+          # leave a clean working tree so later tests can rely on it
+          git checkout -- file.txt
 
       - name: Test pull - basic
         run: |

--- a/branch
+++ b/branch
@@ -153,7 +153,10 @@ local_branch_exists=
 git show-ref --verify --quiet "refs/heads/$branch" && local_branch_exists=1
 
 remote_branch_exists=
-remotes=($(git remote))
+remotes=()
+while IFS= read -r line; do
+  remotes+=("$line")
+done < <(git remote)
 remotes_with_branch=()
 origin_has_branch=
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ FILES=(branch merge pull push stash)
 mkdir -p ${dest}
 
 # Download all scripts
-for s in ${FILES[*]}; do
+for s in "${FILES[@]}"; do
   curl -fsSL -o "${dest}/${s}" "https://raw.githubusercontent.com/git-friendly/git-friendly/main/${s}"
   if [ ! -f "${dest}/${s}" ]; then
     echo

--- a/pull
+++ b/pull
@@ -54,7 +54,7 @@ file_exists() {
 change_dir() {
   file=$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep "$1")
   if [[ -e "./$base_dir$file" ]]; then
-    cd $(dirname "./$base_dir$file")
+    cd "$(dirname "./$base_dir$file")" || return 1
     return 0
   fi
   return 1
@@ -62,7 +62,7 @@ change_dir() {
 
 # Go back to
 reset_dir() {
-  cd "$current_dir"
+  cd "$current_dir" || return 1
 }
 
 # Test whether a file has changed since the pre-pull HEAD.

--- a/push
+++ b/push
@@ -15,7 +15,7 @@ git rev-parse --is-inside-work-tree >/dev/null || exit $?
 # Get parent branch
 # https://stackoverflow.com/a/17843908/1973105
 function get_parent() {
-  git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'
+  git show-branch | grep -F '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'
 }
 
 # Colors
@@ -74,7 +74,7 @@ fi
 # Build GitHub URL: prefer PR URL > compare URL
 remote_url=$(git remote get-url --push $remote)
 
-if [[ "$remote_url" =~ "github.com" ]]; then
+if [[ "$remote_url" =~ github\.com ]]; then
 
   if [[ ${remote_url:0:4} == "git@" ]]; then
     regEx='s/.*\:\(.*\)\.git/\1/'


### PR DESCRIPTION
stacked on top of #128 — most of these tests assume those fixes are in place. github will auto-retarget this to main once that merges.

7 new test cases covering bugs and edges the original 25 missed, plus a separate shellcheck job at warning level (cheap to add, catches the unquoted-var / `[ -z $x ]` stuff we just spent time fixing).

- branch -d on a nonexistent branch must exit non-zero (was silently 0)
- branch name with `/` in it — common feature/* flow, never tested
- detached HEAD: pull/push/merge must fail cleanly with a friendly error
- pull skips `git stash pop` when nothing was actually stashed
- pull's stash pop runs exactly once when something was stashed
- pull's package-manager install hooks (yarn) don't fire when their lockfile didn't change
- push: passthrough flag (--force-with-lease) doesn't get mangled by argument quoting

to test:
- CI should run green once #128 merges
- to replay locally: it's all plain `run:` blocks against a $TMPDIR fixture, no special harness